### PR TITLE
fix: 修复加载时网格布局抖动

### DIFF
--- a/src/components/x-container/panel.tsx
+++ b/src/components/x-container/panel.tsx
@@ -20,6 +20,9 @@ export const XPanel: React.FC<XProps> = ({ attributes, children }) => {
     // console.log('layout', newLayout);
   };
 
+  if (!layout.length) {
+    return <div></div>;
+  }
   return (
     <div className="x-panel full">
       <ReactGridLayout


### PR DESCRIPTION
fix: 修复加载时网格布局抖动

原因：初次加载时，`GridLayout`中`layout=[]`，导致渲染子元素时没有确定的布局，默认按列的形式渲染
解决方法：做个判断，当`layout=[]`时，不渲染子元素