### PR TITLE
Feat commen header enhance

### DIFF
--- a/src/components/base/code-loading.less
+++ b/src/components/base/code-loading.less
@@ -1,5 +1,5 @@
 .code-loading {
-  position: absolute;
+  position: fixed;
   left: 0;
   top: 0;
   z-index: 9999;

--- a/src/components/base/page-loading.tsx
+++ b/src/components/base/page-loading.tsx
@@ -1,10 +1,22 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import CodeLoading from './code-loading';
 
-const PageLoading: React.FC = () => (
-  <div style={{ height: '100vh' }}>
-    <CodeLoading />
-  </div>
-);
+const PageLoading: React.FC = () => {
+
+  useEffect(() => {
+    // 为了确保遮罩层下，没有滚动事件
+    const oldOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = oldOverflow;
+    }
+  }, [])
+
+  return (
+    <div style={{ height: '100vh' }}>
+      <CodeLoading />
+    </div>
+  )
+};
 
 export default PageLoading;

--- a/src/components/x-container/panel.tsx
+++ b/src/components/x-container/panel.tsx
@@ -4,6 +4,7 @@ import * as _ from 'lodash';
 import { WidthProvider, Layout, Responsive, Layouts } from 'react-grid-layout';
 import { XComponentProps } from '@/types';
 import { isEditMode } from '@/utils/location';
+import PageLoading from '../base/page-loading';
 
 const ReactGridLayout = WidthProvider(Responsive);
 type XProps = XComponentProps<{
@@ -23,7 +24,7 @@ export const XPanel: React.FC<XProps> = ({ attributes, children }) => {
   };
 
   if (_.isEmpty(layout)) {
-    return <div></div>;
+    return <PageLoading />;
   }
   return (
     <div className="x-panel full">

--- a/src/components/x-plot/common/header.tsx
+++ b/src/components/x-plot/common/header.tsx
@@ -7,20 +7,30 @@ import { DownOutlined } from '@ant-design/icons';
 
 export const Header: React.FC<XComponentProps> = ({ attributes }) => {
   const { title, options } = attributes;
-  console.log('options', options)
+
+  const onMenuClick = (e) => {
+    const key = e.key;
+    // to do something....
+  }
+
   const overlay = _.isEmpty(options) ? null : (
-    <Menu>
+    <Menu onClick={onMenuClick}>
       {
-        _.map(options, option => (
-          <Menu.Item key={option.value}>{option.label}</Menu.Item>
+        _.map(options, (option, idx) => (
+          <Menu.Item key={idx}>{option.label}</Menu.Item>
         ))
       }
     </Menu>
   )
+
   return (
     <div className={cx('header', 'grid-item-move-handler', attributes.moveHandlerClassName)}>
       <span className="title">{title}</span>
-      {!_.isEmpty(options) && <Dropdown overlay={overlay}><span className={'style-switcher'}>切换样式<DownOutlined /></span></Dropdown>}
+      {_.size(options) > 1 && (
+        <Dropdown overlay={overlay}>
+          <span className={'style-switcher'}>切换样式<DownOutlined /></span>
+        </Dropdown>
+      )}
     </div>
   );
 };

--- a/src/components/x-plot/common/header.tsx
+++ b/src/components/x-plot/common/header.tsx
@@ -1,11 +1,26 @@
 import React from 'react';
 import * as cx from 'classnames';
 import { XComponentProps } from '@/types';
+import { Dropdown, Menu } from 'antd';
+import * as _ from 'lodash';
+import { DownOutlined } from '@ant-design/icons';
 
 export const Header: React.FC<XComponentProps> = ({ attributes }) => {
+  const { title, options } = attributes;
+  console.log('options', options)
+  const overlay = _.isEmpty(options) ? null : (
+    <Menu>
+      {
+        _.map(options, option => (
+          <Menu.Item key={option.value}>{option.label}</Menu.Item>
+        ))
+      }
+    </Menu>
+  )
   return (
     <div className={cx('header', 'grid-item-move-handler', attributes.moveHandlerClassName)}>
-      <span className="title">{attributes.title}</span>
+      <span className="title">{title}</span>
+      {!_.isEmpty(options) && <Dropdown overlay={overlay}><span className={'style-switcher'}>切换样式<DownOutlined /></span></Dropdown>}
     </div>
   );
 };

--- a/src/components/x-plot/common/parse.less
+++ b/src/components/x-plot/common/parse.less
@@ -15,6 +15,9 @@
 
   .header {
     margin-bottom: 16px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
 
     .title {
       font-family: @font-family;
@@ -23,6 +26,16 @@
       color: rgba(0, 0, 0, 0.85);
       letter-spacing: -0.2px;
       font-weight: 500;
+    }
+
+    .style-switcher {
+      color: rgba(0, 0, 0, 0.45);
+      font-size: 12px;
+      display: flex;
+      align-items: center;
+      :last-child {
+        margin-left: 4px;
+      }
     }
   }
 }


### PR DESCRIPTION
1、layout为空时，添加pageLoading组建
2、pageLoading 组件加强，目的禁止遮罩层下的 dom 触发滚动事件
3、common/header 加强，根据 options 的长度，大于1，展示切换样式按钮